### PR TITLE
[postbuildlint] Don't read lib info twice

### DIFF
--- a/src/vcpkg/postbuildlint.cpp
+++ b/src/vcpkg/postbuildlint.cpp
@@ -629,75 +629,63 @@ namespace vcpkg
         return LintStatus::SUCCESS;
     }
 
+    static std::vector<Optional<LibInformation>> get_lib_info(const Filesystem& fs, View<Path> libs)
+    {
+        std::vector<Optional<LibInformation>> maybe_lib_infos(libs.size());
+        std::transform(
+            libs.begin(), libs.end(), maybe_lib_infos.begin(), [&fs](const Path& lib) -> Optional<LibInformation> {
+                auto maybe_rfp = fs.try_open_for_read(lib);
+
+                if (auto file_handle = maybe_rfp.get())
+                {
+                    auto maybe_lib_info = read_lib_information(*file_handle);
+                    if (auto lib_info = maybe_lib_info.get())
+                    {
+                        return std::move(*lib_info);
+                    }
+                    return nullopt;
+                }
+                return nullopt;
+            });
+        return maybe_lib_infos;
+    }
+
     static LintStatus check_lib_architecture(const std::string& expected_architecture,
                                              const std::string& cmake_system_name,
-                                             const std::vector<Path>& files,
-                                             const ReadOnlyFilesystem& fs,
+                                             View<Path> files,
+                                             View<Optional<LibInformation>> maybe_lib_infos,
                                              MessageSink& msg_sink)
     {
         std::vector<FileAndArch> binaries_with_invalid_architecture;
-        if (Util::Vectors::contains(windows_system_names, cmake_system_name))
+        for (size_t i = 0; i < files.size(); ++i)
         {
-            for (const Path& file : files)
+            auto& maybe_lib_information = maybe_lib_infos[i];
+            auto& file = files[i];
+
+            if (!maybe_lib_information.has_value())
             {
-                if (!Strings::case_insensitive_ascii_equals(file.extension(), ".lib"))
-                {
-                    continue;
-                }
+                continue;
+            }
 
-                auto maybe_lib_information = fs.try_open_for_read(file).then(
-                    [](ReadFilePointer&& file_handle) { return read_lib_information(file_handle); });
-
-                if (!maybe_lib_information.has_value())
+            auto machine_types = maybe_lib_information.value_or_exit(VCPKG_LINE_INFO).machine_types;
+            {
+                auto llvm_bitcode = std::find(machine_types.begin(), machine_types.end(), MachineType::LLVM_BITCODE);
+                if (llvm_bitcode != machine_types.end())
                 {
-                    continue;
-                }
-
-                auto&& machine_types = maybe_lib_information.value_or_exit(VCPKG_LINE_INFO).machine_types;
-                {
-                    auto llvm_bitcode =
-                        std::find(machine_types.begin(), machine_types.end(), MachineType::LLVM_BITCODE);
-                    if (llvm_bitcode != machine_types.end())
-                    {
-                        machine_types.erase(llvm_bitcode);
-                    }
-                }
-
-                auto printable_machine_types =
-                    Util::fmap(machine_types, [](MachineType mt) { return get_printable_architecture(mt); });
-                // Either machine_types is empty (meaning this lib is architecture independent), or
-                // we need at least one of the machine types to match.
-                // Agnostic example: Folly's debug library, LLVM LTO libraries
-                // Multiple example: arm64x libraries
-                if (!printable_machine_types.empty() &&
-                    !Util::Vectors::contains(printable_machine_types, expected_architecture))
-                {
-                    binaries_with_invalid_architecture.push_back({file, Strings::join(",", printable_machine_types)});
+                    machine_types.erase(llvm_bitcode);
                 }
             }
-        }
-        else if (cmake_system_name == "Darwin")
-        {
-            const auto requested_arch = expected_architecture == "x64" ? "x86_64" : expected_architecture;
-            for (const Path& file : files)
+
+            auto printable_machine_types =
+                Util::fmap(machine_types, [](MachineType mt) { return get_printable_architecture(mt); });
+            // Either machine_types is empty (meaning this lib is architecture independent), or
+            // we need at least one of the machine types to match.
+            // Agnostic example: Folly's debug library, LLVM LTO libraries
+            // Multiple example: arm64x libraries
+            if (!printable_machine_types.empty() &&
+                !Util::Vectors::contains(printable_machine_types, expected_architecture))
             {
-                auto cmd = Command{"lipo"}.string_arg("-archs").string_arg(file);
-                auto maybe_output = flatten_out(cmd_execute_and_capture_output(cmd), "lipo");
-                if (const auto output = maybe_output.get())
-                {
-                    if (!Util::Vectors::contains(Strings::split(Strings::trim(*output), ' '), requested_arch))
-                    {
-                        binaries_with_invalid_architecture.push_back({file, std::move(*output)});
-                    }
-                }
-                else
-                {
-                    msg_sink.println_error(msg::format(msgFailedToDetermineArchitecture,
-                                                       msg::path = file,
-                                                       msg::command_line = cmd.command_line())
-                                               .append_raw('\n')
-                                               .append(maybe_output.error()));
-                }
+                binaries_with_invalid_architecture.push_back({file, Strings::join(",", printable_machine_types)});
             }
         }
 
@@ -993,17 +981,17 @@ namespace vcpkg
         }
     }
 
-    static LintStatus check_crt_linkage_of_libs(const ReadOnlyFilesystem& fs,
-                                                const BuildInfo& build_info,
+    static LintStatus check_crt_linkage_of_libs(const BuildInfo& build_info,
                                                 bool expect_release,
                                                 const std::vector<Path>& libs,
+                                                View<Optional<LibInformation>> lib_infos,
                                                 MessageSink& msg_sink)
     {
         std::vector<BuildTypeAndFile> libs_with_invalid_crt;
-        for (const Path& lib : libs)
+        for (size_t i = 0; i < libs.size(); ++i)
         {
-            auto maybe_lib_info = fs.try_open_for_read(lib).then(
-                [](ReadFilePointer&& lib_file) { return read_lib_information(lib_file); });
+            auto& maybe_lib_info = lib_infos[i];
+            auto& lib = libs[i];
 
             if (!maybe_lib_info.has_value())
             {
@@ -1393,14 +1381,28 @@ namespace vcpkg
 
         if (windows_target)
         {
+            auto release_lib_info = get_lib_info(fs, release_libs);
+            Optional<std::vector<Optional<LibInformation>>> debug_lib_info;
+
+            if (!build_info.policies.is_enabled(BuildPolicy::SKIP_ARCHITECTURE_CHECK) ||
+                !build_info.policies.is_enabled(BuildPolicy::ONLY_RELEASE_CRT))
+            {
+                debug_lib_info.emplace(get_lib_info(fs, release_libs));
+            }
+
             Debug::println("Running windows targeting post-build checks");
             if (!build_info.policies.is_enabled(BuildPolicy::SKIP_ARCHITECTURE_CHECK))
             {
-                std::vector<Path> libs;
-                libs.insert(libs.cend(), debug_libs.cbegin(), debug_libs.cend());
-                libs.insert(libs.cend(), release_libs.cbegin(), release_libs.cend());
-                error_count += check_lib_architecture(
-                    pre_build_info.target_architecture, pre_build_info.cmake_system_name, libs, fs, msg_sink);
+                error_count += check_lib_architecture(pre_build_info.target_architecture,
+                                                      pre_build_info.cmake_system_name,
+                                                      release_libs,
+                                                      release_lib_info,
+                                                      msg_sink);
+                error_count += check_lib_architecture(pre_build_info.target_architecture,
+                                                      pre_build_info.cmake_system_name,
+                                                      debug_libs,
+                                                      *debug_lib_info.get(),
+                                                      msg_sink);
             }
 
             std::vector<Path> debug_dlls = fs.get_regular_files_recursive(debug_bin_dir, IgnoreErrors{});
@@ -1444,10 +1446,11 @@ namespace vcpkg
 
             if (!build_info.policies.is_enabled(BuildPolicy::ONLY_RELEASE_CRT))
             {
-                error_count += check_crt_linkage_of_libs(fs, build_info, false, debug_libs, msg_sink);
+                error_count +=
+                    check_crt_linkage_of_libs(build_info, false, debug_libs, *debug_lib_info.get(), msg_sink);
             }
 
-            error_count += check_crt_linkage_of_libs(fs, build_info, true, release_libs, msg_sink);
+            error_count += check_crt_linkage_of_libs(build_info, true, release_libs, release_lib_info, msg_sink);
         }
 
         error_count += check_no_empty_folders(fs, package_dir, msg_sink);


### PR DESCRIPTION
Library information was read twice from the same files: once in `check_lib_architecture` and once in `check_crt_linkage_of_libs`. This caused a performance regression because the same thing was done twice. This PR moves reading the libraries to a single function (`get_lib_info`) which is only called once.

Additionally, `check_lib_architecture` performed the check `cmake_system_name == "Darwin"` but this function is only called on Windows. Therefore, this check is unnecessary and I removed the code inside it.